### PR TITLE
Added option to include a dictionary of extra headers for send_mail_template.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,8 @@ As mentioned above, the following function is provided in
 the ``email_extras.utils`` module::
 
   send_mail_template(subject, template, addr_from, addr_to,
-      fail_silently=False, attachments=None, context=None)
+      fail_silently=False, attachments=None, context=None,
+      headers=None)
 
 The arguments that differ from ``django.core.mail.send_mail`` are
 ``template`` and ``context``. The ``template`` argument is simply
@@ -96,6 +97,10 @@ file name / file data pair.
 The ``context`` argument is simply a dictionary that is used to
 populate the email templates, much like a normal request context
 would be used for a regular Django template.
+
+The ``headers`` argument is a dictionary of extra headers to put on
+the message. The keys are the header name and values are the header
+values.
 
 Configuration
 =============

--- a/email_extras/utils.py
+++ b/email_extras/utils.py
@@ -25,7 +25,8 @@ def addresses_for_key(gpg, key):
 
 
 def send_mail(subject, body_text, addr_from, addr_to, fail_silently=False,
-              attachments=None, body_html=None, connection=None):
+              attachments=None, body_html=None, connection=None,
+              headers=None):
     """
     Sends a multipart email containing text and html versions which
     are encrypted for each recipient that has a valid gpg key
@@ -66,7 +67,8 @@ def send_mail(subject, body_text, addr_from, addr_to, fail_silently=False,
     # Send emails.
     for addr in addr_to:
         msg = EmailMultiAlternatives(subject, encrypt_if_key(body_text, addr),
-                                     addr_from, [addr], connection=connection)
+                                     addr_from, [addr], connection=connection,
+                                     headers=headers)
         if body_html is not None:
             body_html = encrypt_if_key(body_html, addr)
             msg.attach_alternative(body_html, "text/html")
@@ -79,7 +81,8 @@ def send_mail(subject, body_text, addr_from, addr_to, fail_silently=False,
 
 
 def send_mail_template(subject, template, addr_from, addr_to,
-                       fail_silently=False, attachments=None, context=None, connection=None):
+                       fail_silently=False, attachments=None, context=None,
+                       connection=None, headers=None):
     """
     Send email rendering text and html versions for the specified
     template name using the context dictionary passed in.
@@ -95,4 +98,5 @@ def send_mail_template(subject, template, addr_from, addr_to,
 
     send_mail(subject, render("txt"), addr_from, addr_to,
               fail_silently=fail_silently, attachments=attachments,
-              body_html=render("html"), connection=connection)
+              body_html=render("html"), connection=connection,
+              headers=headers)


### PR DESCRIPTION
Added the option to pass headers to send_mail_template and updated the README to reflect this. I added this because django-forms-builder uses django-email-extras and requires this functionality for a pull request I am about to submit (regarding https://github.com/stephenmcd/django-forms-builder/issues/108), and this seemed like the cleanest solution.
