### PR TITLE
fixed problem with non-ascii character when using BrowsableEmailBackend

### DIFF
--- a/email_extras/backends.py
+++ b/email_extras/backends.py
@@ -23,7 +23,7 @@ class BrowsableEmailBackend(BaseEmailBackend):
                     self.open(body)
 
     def open(self, body):
-        temp = NamedTemporaryFile(delete=False)
-        temp.write(body)
-        temp.close()
+        with NamedTemporaryFile(delete=False) as temp:
+            temp.write(body.encode('utf-8'))
+
         webbrowser.open("file://" + temp.name)


### PR DESCRIPTION
Hi.
I had a problem with non-ascii charaters decoding in templates/messages while using BrowsableEmailBackend. Here is pull-request which fixes this problem.