### PR TITLE
Adding missing migration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ Usage
 =====
 
 Once installed, first add ``email_extras`` to your ``INSTALLED_APPS``
-setting. Then there are two functions for sending email in the
-``email_extras.utils`` module:
+setting and run the migrations. Then there are two functions for sending email
+in the ``email_extras.utils`` module:
 
   * ``send_mail``
   * ``send_mail_template``

--- a/email_extras/migrations/0001_initial.py
+++ b/email_extras/migrations/0001_initial.py
@@ -1,0 +1,39 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Address',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('address', models.CharField(max_length=200)),
+                ('use_asc', models.BooleanField(default=False, editable=False)),
+            ],
+            options={
+                'verbose_name': 'Address',
+                'verbose_name_plural': 'Addresses',
+            },
+        ),
+        migrations.CreateModel(
+            name='Key',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('key', models.TextField()),
+                ('addresses', models.TextField(editable=False)),
+                ('use_asc', models.BooleanField(default=False, help_text="If True, an '.asc' extension will be added to email attachments sent to the address for this key.")),
+            ],
+            options={
+                'verbose_name': 'Key',
+                'verbose_name_plural': 'Keys',
+            },
+        ),
+    ]


### PR DESCRIPTION
Adding a default migration so that `manage.py migrate` works out of the box.