### PR TITLE
Allow failed encryption handling

### DIFF
--- a/email_extras/settings.py
+++ b/email_extras/settings.py
@@ -7,6 +7,8 @@ GNUPG_HOME = getattr(settings, "EMAIL_EXTRAS_GNUPG_HOME", None)
 USE_GNUPG = getattr(settings, "EMAIL_EXTRAS_USE_GNUPG", GNUPG_HOME is not None)
 ALWAYS_TRUST = getattr(settings, "EMAIL_EXTRAS_ALWAYS_TRUST_KEYS", False)
 GNUPG_ENCODING = getattr(settings, "EMAIL_EXTRAS_GNUPG_ENCODING", None)
+ENCRYPTION_FAILED_MESSAGE = getattr(
+    settings, "EMAIL_EXTRAS_ENCRYPTION_FAILED_MESSAGE", "")
 
 if USE_GNUPG:
     try:

--- a/email_extras/settings.py
+++ b/email_extras/settings.py
@@ -7,8 +7,8 @@ GNUPG_HOME = getattr(settings, "EMAIL_EXTRAS_GNUPG_HOME", None)
 USE_GNUPG = getattr(settings, "EMAIL_EXTRAS_USE_GNUPG", GNUPG_HOME is not None)
 ALWAYS_TRUST = getattr(settings, "EMAIL_EXTRAS_ALWAYS_TRUST_KEYS", False)
 GNUPG_ENCODING = getattr(settings, "EMAIL_EXTRAS_GNUPG_ENCODING", None)
-ENCRYPTION_FAILED_MESSAGE = getattr(
-    settings, "EMAIL_EXTRAS_ENCRYPTION_FAILED_MESSAGE", "")
+FAILED_ENCRYPTION_BODY = getattr(
+    settings, "EMAIL_EXTRAS_FAILED_ENCRYPTION_BODY", "")
 
 if USE_GNUPG:
     try:

--- a/email_extras/utils.py
+++ b/email_extras/utils.py
@@ -7,7 +7,7 @@ from django.utils import six
 from django.utils.encoding import smart_text
 
 from email_extras.settings import (USE_GNUPG, GNUPG_HOME, ALWAYS_TRUST,
-                                   GNUPG_ENCODING, ENCRYPTION_FAILED_MESSAGE)
+                                   GNUPG_ENCODING, FAILED_ENCRYPTION_BODY)
 
 
 if USE_GNUPG:
@@ -27,11 +27,11 @@ def addresses_for_key(gpg, key):
     return addresses
 
 
-def get_body_for_failed_encryption(body, addr):
+def get_failed_encryption_body(body, addr):
     """
     Meant to be monkey patched if required.
     """
-    return ENCRYPTION_FAILED_MESSAGE
+    return FAILED_ENCRYPTION_BODY
 
 
 def send_mail(subject, body_text, addr_from, addr_to, fail_silently=False,
@@ -68,7 +68,7 @@ def send_mail(subject, body_text, addr_from, addr_to, fail_silently=False,
             encrypted = gpg.encrypt(body, addr_list[0],
                                     always_trust=ALWAYS_TRUST)
             if encrypted == "" and body != "":  # encryption failed
-                return get_body_for_failed_encryption(body, addr_list[0])
+                return get_failed_encryption_body(body, addr_list[0])
             return smart_text(encrypted)
         return body
 


### PR DESCRIPTION
If the encryption of a mail body fails, e.g. because the key is expired, python-gnupg just returns an empty string, which then becomes the mail body.  See [python-gnupg docs](https://pythonhosted.org/python-gnupg/#encryption-and-decryption):

> Note Any public key provided for encryption should be trusted, otherwise encryption fails but without any warning. This is because gpg just prints a message to the console, but does not provide a specific error indication that the Python wrapper can use.

This pull request aims to make it easier to add custom error handling in this case.
It's easy to tell that the encryption failed: `encrypted == "" and body != ""`.
In this case `utils.get_failed_encryption_body(body, addr)` would be called, where `body` is the original/unencrypted body.
That method just returns `settings.FAILED_ENCRYPTION_BODY`, which is set to "" (so, it's the same result as before), but could be overwritten with a more useful message.
More important (for me), `utils.get_failed_encryption_body(body, addr)` can be easily monkey patched,
which allows to add any kind of custom error handling and to return whatever could be useful. 

