### PR TITLE
Fix all flake8 issues (ignore E501 and exclude docs/conf.py)

### DIFF
--- a/email_extras/admin.py
+++ b/email_extras/admin.py
@@ -4,6 +4,7 @@ from email_extras.settings import USE_GNUPG
 
 if USE_GNUPG:
     from django.contrib import admin
+
     from email_extras.models import Key, Address
     from email_extras.forms import KeyForm
 
@@ -12,13 +13,12 @@ if USE_GNUPG:
         list_display = ('__str__', 'email_addresses')
         readonly_fields = ('fingerprint', )
 
-
     class AddressAdmin(admin.ModelAdmin):
         list_display = ('__str__', 'key')
         readonly_fields = ('key', )
 
         def has_add_permission(self, request):
-                return False
+            return False
 
     admin.site.register(Key, KeyAdmin)
     admin.site.register(Address, AddressAdmin)

--- a/email_extras/backends.py
+++ b/email_extras/backends.py
@@ -3,7 +3,6 @@ from tempfile import NamedTemporaryFile
 import webbrowser
 
 from django.conf import settings
-from django.core.mail import EmailMultiAlternatives
 from django.core.mail.backends.base import BaseEmailBackend
 
 

--- a/email_extras/models.py
+++ b/email_extras/models.py
@@ -24,9 +24,9 @@ if USE_GNUPG:
 
         key = models.TextField()
         fingerprint = models.CharField(max_length=200, blank=True, editable=False)
-        use_asc = models.BooleanField(default=False, help_text=_("If True, "
-            "an '.asc' extension will be added to email attachments sent "
-            "to the address for this key."))
+        use_asc = models.BooleanField(default=False, help_text=_(
+            "If True, an '.asc' extension will be added to email attachments "
+            "sent to the address for this key."))
 
         def __str__(self):
             return self.fingerprint
@@ -50,7 +50,6 @@ if USE_GNUPG:
                 address, _ = Address.objects.get_or_create(key=self, address=address)
                 address.use_asc = self.use_asc
                 address.save()
-
 
     @python_2_unicode_compatible
     class Address(models.Model):

--- a/email_extras/settings.py
+++ b/email_extras/settings.py
@@ -10,6 +10,6 @@ GNUPG_ENCODING = getattr(settings, "EMAIL_EXTRAS_GNUPG_ENCODING", None)
 
 if USE_GNUPG:
     try:
-        import gnupg
+        import gnupg  # noqa: F401
     except ImportError:
         raise ImproperlyConfigured("Could not import gnupg")

--- a/setup.py
+++ b/setup.py
@@ -16,20 +16,20 @@ if sys.argv[:2] == ["setup.py", "bdist_wheel"]:
 
 
 setup(
-    name = "django-email-extras",
-    version = __import__("email_extras").__version__,
-    author = "Stephen McDonald",
-    author_email = "steve@jupo.org",
-    description = "A Django reusable app providing the ability to "
-                  "send PGP encrypted and multipart emails using "
-                  "the Django templating system.",
-    long_description = open("README.rst").read(),
-    url = "https://github.com/stephenmcd/django-email-extras",
-    packages = find_packages(),
-    zip_safe = False,
-    include_package_data = True,
-    install_requires=["python-gnupg", "sphinx-me",],
-    classifiers = [
+    name="django-email-extras",
+    version=__import__("email_extras").__version__,
+    author="Stephen McDonald",
+    author_email="steve@jupo.org",
+    description="A Django reusable app providing the ability to send PGP "
+                "encrypted and multipart emails using the Django templating "
+                "system.",
+    long_description=open("README.rst").read(),
+    url="https://github.com/stephenmcd/django-email-extras",
+    packages=find_packages(),
+    zip_safe=False,
+    include_package_data=True,
+    install_requires=["python-gnupg", "sphinx-me"],
+    classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Fix formatting issues highlighted by running flake8:

```bash
flake8 --ignore=E501 --exclude=docs/conf.py
```

* E501 is "Line too long", and for some lines that would make them less readable
* The `docs/conf.py` file is autogenerated, so I excluded that entirely