### PR TITLE
Pass on non-HTML mail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,7 @@ There are two settings you can configure in your project's
     for more info.
   * ``EMAIL_EXTRAS_ALWAYS_TRUST_KEYS`` - Skip key validation and assume
     that used keys are always fully trusted.
+  * ``EMAIL_EXTRAS_ACTUAL_DEBUG_BACKEND`` - Dotted import path to the "real" email backend you wish to use during development
 
 
 Local Browser Testing
@@ -146,3 +147,10 @@ With this configured, each time a multipart email is sent, it will
 be written to a temporary file, which is then automatically opened
 in a local web browser. Suffice to say, this should only be enabled
 during development!
+
+In addition to opening HTML mail in your web browser, you can also configure
+the actual backend to use. This is useful if you want to view non-HTML mail
+in your terminal. To use this feature, simply set this option in your
+development ``settings.py`` module::
+
+  EMAIL_EXTRAS_ACTUAL_DEBUG_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/email_extras/settings.py
+++ b/email_extras/settings.py
@@ -3,10 +3,15 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 
+DEFAULT_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+DEBUG = getattr(settings, "DEBUG")
 GNUPG_HOME = getattr(settings, "EMAIL_EXTRAS_GNUPG_HOME", None)
 USE_GNUPG = getattr(settings, "EMAIL_EXTRAS_USE_GNUPG", GNUPG_HOME is not None)
 ALWAYS_TRUST = getattr(settings, "EMAIL_EXTRAS_ALWAYS_TRUST_KEYS", False)
 GNUPG_ENCODING = getattr(settings, "EMAIL_EXTRAS_GNUPG_ENCODING", None)
+ACTUAL_DEBUG_BACKEND = getattr(settings, "EMAIL_EXTRAS_ACTUAL_DEBUG_BACKEND",
+                               DEFAULT_BACKEND)
 
 if USE_GNUPG:
     try:


### PR DESCRIPTION
This is useful if you want to open HTML parts of emails in your web browser **and** you want to see the non-HTML parts in your terminal, or logged to a file.

This adds a new option `EMAIL_EXTRAS_ACTUAL_DEBUG_BACKEND` and passes email onto it.

The default for this is Django's console backend, so non-HTML parts will display in the developer's terminal. To completely turn that off, the option should be `django.core.mail.backends.dummy.EmailBackend`.