### PR TITLE
Don't require sphinx on installation, only for the 'dev' requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,14 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,
-    install_requires=["python-gnupg", "sphinx-me"],
+    install_requires=[
+        "python-gnupg"
+    ],
+    extras_require={
+        'dev': [
+            "sphinx-me",
+        ]
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
Similar to https://github.com/stephenmcd/django-overextends/commit/85627139f68f0b5bd0fb6a79dd381043ea007b14.

Removes the *installation* dependency on `sphinx-me`, and creates an extra requirement called `dev` that includes on `sphinx-me`. Users can install development dependencies with `pip install django-email-extras[dev]`.