### PR TITLE
fix exception condition and add mail data

### DIFF
--- a/email_extras/utils.py
+++ b/email_extras/utils.py
@@ -16,7 +16,11 @@ if USE_GNUPG:
 
 
 class EncryptionFailedError(Exception):
-    pass
+    def __init__(self, addr, body):
+        self.body = body
+        self.addr = addr
+        super(EncryptionFailedError, self).__init__(
+            "Encrypting mail to %s failed.", addr)
 
 
 def addresses_for_key(gpg, key):
@@ -82,10 +86,10 @@ def send_mail(subject, body_text, addr_from, recipient_list,
         if has_pgp_key(addr_list[0]):
             encrypt_result = gpg.encrypt(body, addr_list[0],
                                          always_trust=ALWAYS_TRUST)
-            if encrypted == "" and body != "":  # encryption failed
-                raise EncryptionFailedError("Encrypting mail to %s failed.",
-                                            addr_list[0])
-            return smart_text(encrypted)
+            if str(encrypt_result) == "" and body != "":  # encryption failed
+                raise EncryptionFailedError(addr_list[0], body)
+
+            return smart_text(encrypt_result)
         return body
 
     # Load attachments and create name/data tuples.


### PR DESCRIPTION
The commit [Throw an exception if encryption fails](https://github.com/stephenmcd/django-email-extras/commit/b996a4283cbc417b5f84b2e815671e248857a0f8) renamed `encrypted` in `def encrypt_if_key` to `encrypt_result` but does not use the new name anywhere (`encryption` is still defined but it is a list of addresses and not the encrypted body)
So the exception is not raised when it should and `encrypt_if_key` returns the wrong thing when encryption is successful.

Furthermore i added the body and the address as exception parameters, so they can be used in the exception handling.